### PR TITLE
update python test triggers to be more selective

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -5,8 +5,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - cortex_xdr_client/**
+      - poetry.lock
+      - pyproject.toml
+      - .github/workflows/python-test.yml
   pull_request:
-
+    paths:
+      - cortex_xdr_client/**
+      - poetry.lock
+      - pyproject.toml
+      - .github/workflows/python-test.yml
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently python test is ran when commits are pushed on all paths (including those without code to be tested). This PR reduces the number of actions to be run when non-code updates are pushed/pull requested.