### PR TITLE
Fix enum error

### DIFF
--- a/cortex_xdr_client/api/models/endpoints.py
+++ b/cortex_xdr_client/api/models/endpoints.py
@@ -20,6 +20,7 @@ class EndpointPlatform(Enum):
     linux = "AGENT_OS_LINUX"
     windows = "AGENT_OS_WINDOWS"
     macos = "AGENT_OS_MACOS"
+    mac = "AGENT_OS_MAC"
 
 
 class IsolateStatus(Enum):


### PR DESCRIPTION
while parsing the response from the get_endpoint method some endpoints were seen to return AGENT_OS_MAC in the `os_type` attribute causing program to throw ValidationError