### PR TITLE
Add missing Endpoint Status

### DIFF
--- a/cortex_xdr_client/api/models/endpoints.py
+++ b/cortex_xdr_client/api/models/endpoints.py
@@ -10,6 +10,7 @@ class EndpointStatus(Enum):
     """
     connected = "CONNECTED"
     disconnected = "DISCONNECTED"
+    lost = "LOST"
 
 
 class EndpointPlatform(Enum):


### PR DESCRIPTION
While retrieveing the endpoint the client errors out because of a missing status "LOST"