### PR TITLE
Add missing return_value for script execution results

### DIFF
--- a/cortex_xdr_client/api/models/scripts.py
+++ b/cortex_xdr_client/api/models/scripts.py
@@ -70,6 +70,7 @@ class ScriptExecutionResult(BaseModel):
     retrieved_files: Optional[int]
     failed_files: Optional[int]
     retention_date: Optional[int]
+    _return_value: List[str]
 
 
 class GetScriptExecutionResults(BaseModel):


### PR DESCRIPTION
When scripts like list_directories execute, the stdout is stored in return_value attribute instead of standart_output