### PR TITLE
Add implementation for `Set an Endpoint alias` endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Currently, it supports the following Cortex XDR **Prevent & Pro** APIs:
 -  `Isolate Endpoints <https://cortex-panw.stoplight.io/docs/cortex-xdr/9c730a966cdd8-isolate-endpoints>`__
 -  `Unisolate Endpoints <https://cortex-panw.stoplight.io/docs/cortex-xdr/c719336adb46b-unisolate-endpoints>`__
 -  `Scan Endpoints <https://cortex-panw.stoplight.io/docs/cortex-xdr/2e666ee0be1c6-scan-endpoints>`__
+-  `Set an Endpoint Alias <https://cortex-panw.stoplight.io/docs/cortex-xdr/c1ff89fa71c74-set-an-endpoint-alias>`__
 -  `Retrieve File <https://cortex-panw.stoplight.io/docs/cortex-xdr/08b1ba9fcfae0-retrieve-file>`__
 -  `Quarantine File <https://cortex-panw.stoplight.io/docs/cortex-xdr/76e8cca7fcb2e-quarantine-files>`__
 

--- a/cortex_xdr_client/api/endpoints_api.py
+++ b/cortex_xdr_client/api/endpoints_api.py
@@ -245,7 +245,7 @@ class EndpointsAPI(BaseAPI):
         if endpoint_status is not None:
             filters.append(request_filter("endpoint_status", "in", endpoint_status))
 
-        request_data = new_request_data(filters=filters)
+        request_data = new_request_data(filters=filters, other={"alias": new_alias})
 
         response = self._call(call_name="update_agent_name",
                               json_value=request_data)

--- a/cortex_xdr_client/api/endpoints_api.py
+++ b/cortex_xdr_client/api/endpoints_api.py
@@ -233,7 +233,22 @@ class EndpointsAPI(BaseAPI):
                            alias: List[str] = None,
                            isolate: List[IsolateStatus] = None,
                            hostname: List[str] = None,
-                           ):
+                           ) -> Optional[ResponseStatusResponse]:
+        """
+        Set or modify an Alias field for your endpoints.
+
+        :param new_alias: The alias name you want to set or modify.
+        :param endpoint_id_list: List of endpoint IDs.
+        :param endpoint_status: Status of the endpoint ID.
+        :param dist_name: Distribution / Installation Package name.
+        :param ip_list: List of IP addresses.
+        :param group_name: Group name the agent belongs to.
+        :param platform: Platform name.
+        :param alias: Alias name.
+        :param isolate: If the endpoint was isolated.
+        :param hostname: Hostname
+        :return: A ResponseStatusResponse if successful.
+        """
         filters = self._get_common_endpoint_filters(endpoint_id_list=endpoint_id_list,
                                                     dist_name=dist_name,
                                                     ip_list=ip_list,

--- a/cortex_xdr_client/api/endpoints_api.py
+++ b/cortex_xdr_client/api/endpoints_api.py
@@ -8,6 +8,7 @@ from cortex_xdr_client.api.models.endpoints import (EndpointPlatform,
                                                     GetEndpointResponse,
                                                     IsolateStatus,
                                                     ResponseActionResponse,
+                                                    ResponseStatusResponse,
                                                     ScanStatus,
                                                     )
 from cortex_xdr_client.api.models.filters import (new_request_data, request_filter, request_gte_lte_filter)
@@ -219,6 +220,37 @@ class EndpointsAPI(BaseAPI):
         response = self._call(call_name="scan",
                               json_value=request_data)
         return ResponseActionResponse.parse_obj(response.json())
+
+    # https://docs-cortex.paloaltonetworks.com/r/Cortex-XDR-REST-API/Set-an-Endpoint-Alias
+    def set_endpoint_alias(self,
+                           new_alias: str,
+                           endpoint_id_list: List[str] = None,
+                           endpoint_status: EndpointStatus = None,
+                           dist_name: str = None,
+                           ip_list: List[str] = None,
+                           group_name: List[str] = None,
+                           platform: List[EndpointPlatform] = None,
+                           alias: List[str] = None,
+                           isolate: List[IsolateStatus] = None,
+                           hostname: List[str] = None,
+                           ):
+        filters = self._get_common_endpoint_filters(endpoint_id_list=endpoint_id_list,
+                                                    dist_name=dist_name,
+                                                    ip_list=ip_list,
+                                                    group_name=group_name,
+                                                    platform=platform,
+                                                    alias=alias,
+                                                    isolate=isolate,
+                                                    hostname=hostname)
+        if endpoint_status is not None:
+            filters.append(request_filter("endpoint_status", "in", endpoint_status))
+
+        request_data = new_request_data(filters=filters)
+
+        response = self._call(call_name="update_agent_name",
+                              json_value=request_data)
+
+        return ResponseStatusResponse.parse_obj(response.json())
 
     # https://docs.paloaltonetworks.com/cortex/cortex-xdr/cortex-xdr-api/cortex-xdr-apis/response-actions/retrieve-file.html
     def retrieve_file(self,

--- a/cortex_xdr_client/api/models/endpoints.py
+++ b/cortex_xdr_client/api/models/endpoints.py
@@ -108,3 +108,7 @@ class ResponseActionResponseItem(BaseModel):
 
 class ResponseActionResponse(BaseModel):
     reply: ResponseActionResponseItem
+
+
+class ResponseStatusResponse(BaseModel):
+    reply: bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -865,6 +865,16 @@ def get_scripts_response():
 
 
 @pytest.fixture
+def get_set_endpoint_alias_response():
+    response = r"""
+    {
+        "reply": true
+    }
+    """
+    return json.loads(response)
+
+
+@pytest.fixture
 def get_script_metadata_response():
     response = r"""
        {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,10 @@
 from cortex_xdr_client.api.models.action_status import GetActionStatus
 from cortex_xdr_client.api.models.alerts import GetAlertsResponse
-from cortex_xdr_client.api.models.endpoints import GetAllEndpointsResponse, GetEndpointResponse, ResponseActionResponse
+from cortex_xdr_client.api.models.endpoints import (GetAllEndpointsResponse,
+                                                    GetEndpointResponse,
+                                                    ResponseActionResponse,
+                                                    ResponseStatusResponse
+                                                    )
 from cortex_xdr_client.api.models.incidents import GetExtraIncidentDataResponse, GetIncidentsResponse
 from cortex_xdr_client.api.models.scripts import (GetScriptExecutionResults,
                                                   GetScriptMetadataResponse,
@@ -53,6 +57,13 @@ def test_scan_endpoints(requests_mock, cortex_client, get_scan_endpoints_respons
     requests_mock.post(cortex_client.endpoints_api._get_url("scan"),
                        json=get_scan_endpoints_response)
     assert ResponseActionResponse.parse_obj(get_scan_endpoints_response) == cortex_client.endpoints_api.scan_endpoints()
+
+
+def test_set_endpoint_aliast(requests_mock, cortex_client, get_set_endpoint_alias_response):
+    requests_mock.post(cortex_client.endpoints_api._get_url("update_agent_name"),
+                       json=get_set_endpoint_alias_response)
+    assert ResponseStatusResponse.parse_obj(
+        get_set_endpoint_alias_response) == cortex_client.endpoints_api.set_endpoint_alias('new_alias')
 
 
 def test_get_scripts(requests_mock, cortex_client, get_scripts_response):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,7 +59,7 @@ def test_scan_endpoints(requests_mock, cortex_client, get_scan_endpoints_respons
     assert ResponseActionResponse.parse_obj(get_scan_endpoints_response) == cortex_client.endpoints_api.scan_endpoints()
 
 
-def test_set_endpoint_aliast(requests_mock, cortex_client, get_set_endpoint_alias_response):
+def test_set_endpoint_alias(requests_mock, cortex_client, get_set_endpoint_alias_response):
     requests_mock.post(cortex_client.endpoints_api._get_url("update_agent_name"),
                        json=get_set_endpoint_alias_response)
     assert ResponseStatusResponse.parse_obj(


### PR DESCRIPTION
This pull request adds support for [Set an Endpoint Alias](https://cortex-panw.stoplight.io/docs/cortex-xdr/c1ff89fa71c74-set-an-endpoint-alias).