### PR TITLE
fix(api/base_api): Fix the static method `extend` of BaseAPI not taking effect

### DIFF
--- a/cortex_xdr_client/api/base_api.py
+++ b/cortex_xdr_client/api/base_api.py
@@ -25,8 +25,7 @@ class BaseAPI:
         if header_params is None:
             header_params = {}
         url = self._get_url(call_name)
-        headers = self._auth.get_headers()
-        self.extend(headers, header_params)
+        headers = self.extend(self._auth.get_headers(), header_params)
 
         return self._execute_call(url=url,
                                   method=method,


### PR DESCRIPTION
I'm very pleased to discover such an excellent library, it's been a great help to me. During my usage, I found that the static method `extend` in the BaseAPI class doesn't seem to be effective.